### PR TITLE
feat: add Redis support

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,19 @@
+## What
+
+<!-- Briefly describe what was done -->
+
+## Why
+
+<!-- Explain why this change is needed -->
+
+## How to test
+
+<!-- Steps to verify the behavior, e.g. tokens validation, expired tokens, login/logout flows -->
+
+## Security considerations
+
+<!-- Optional: note if this change affects security, introduces risks or mitigations -->
+
+---
+
+Closes #

--- a/AuthCore.API/AuthCore.API.csproj
+++ b/AuthCore.API/AuthCore.API.csproj
@@ -18,6 +18,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="9.0.5" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.21.2" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="9.0.4" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="8.1.1" />

--- a/AuthCore.API/appsettings.json
+++ b/AuthCore.API/appsettings.json
@@ -6,6 +6,9 @@
   "Identity": {
     "DefaultUserRole": "User"
   },
+  "Redis": {
+    "ConnectionString": "192.168.1.252:6379"
+  },
   "Logging": {
     "LogLevel": {
       "Default": "Warning"

--- a/AuthCore.Persistence/Stores/RedisRefreshTokenStore.cs
+++ b/AuthCore.Persistence/Stores/RedisRefreshTokenStore.cs
@@ -1,0 +1,57 @@
+﻿using System.Text.Json;
+using Microsoft.Extensions.Caching.Distributed;
+using AuthCore.Abstractions.Interfaces;
+using AuthCore.Abstractions.Models;
+
+namespace AuthCore.Persistence.Stores
+{
+    public class RedisRefreshTokenStore(IDistributedCache cache) : IRefreshTokenStore
+    {
+        public async Task SaveRefreshTokenAsync(RefreshTokenInfo refreshToken)
+        {
+            var data = new TokenData { UserId = refreshToken.UserId, Expires = refreshToken.Expires };
+            var json = JsonSerializer.Serialize(data);
+
+            var ttl = refreshToken.Expires - DateTime.UtcNow;
+            if (ttl <= TimeSpan.Zero)
+                throw new ArgumentException("Token expiration time must be in the future.", nameof(refreshToken));
+
+            var options = new DistributedCacheEntryOptions
+            {
+                AbsoluteExpirationRelativeToNow = ttl
+            };
+
+            await cache.SetStringAsync(GetKey(refreshToken.Token), json, options);
+        }
+
+        public async Task<RefreshTokenInfo?> GetRefreshTokenAsync(string refreshToken)
+        {
+            var json = await cache.GetStringAsync(GetKey(refreshToken));
+
+            if (string.IsNullOrEmpty(json)) return null;
+
+            var data = JsonSerializer.Deserialize<TokenData>(json);
+            if (data == null) return null;
+
+            return new RefreshTokenInfo
+            {
+                Token = refreshToken,
+                UserId = data.UserId,
+                Expires = data.Expires
+            };
+        }
+
+        public async Task DeleteRefreshTokenAsync(string refreshToken)
+        {
+            await cache.RemoveAsync(GetKey(refreshToken));
+        }
+
+        private static string GetKey(string token) => $"refreshToken:{token}";
+
+        private record TokenData
+        {
+            public required string UserId { get; init; }
+            public DateTime Expires { get; init; }
+        }
+    }
+}


### PR DESCRIPTION
## What

Added Redis support for storing refresh tokens. This will improve performance compared to the current PostgreSQL storage by using Redis as an in-memory database. The feature is activated if the `appconfig.json` contains the Redis configuration section:

```json
"Redis": {
  "ConnectionString": "127.0.0.1:6379"
}
```

Manual testing was performed for storing refresh tokens in both PostgreSQL and Redis databases. All existing tests pass successfully.

## Why

Using Redis for refresh token storage improves performance and scalability by leveraging an in-memory database, reducing latency compared to disk-based PostgreSQL storage.

## How to test

- Configure Redis connection in `appconfig.json`.
- Perform login/logout flows and verify refresh token storage and retrieval.
- Run existing unit and integration tests to ensure no regressions.

## Security considerations

Storing refresh tokens in Redis introduces dependency on Redis security and availability. Ensure Redis is properly secured and access-restricted.

---

Closes #
