### PR TITLE
chore: support environment-based configuration files and minor cleanup

### DIFF
--- a/AuthCore.API/AuthCore.API.csproj
+++ b/AuthCore.API/AuthCore.API.csproj
@@ -18,6 +18,13 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Remove="Logs\**" />
+    <Content Remove="Logs\**" />
+    <EmbeddedResource Remove="Logs\**" />
+    <None Remove="Logs\**" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="9.0.5" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.21.2" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="9.0.4" />
@@ -28,10 +35,6 @@
     <ProjectReference Include="..\AuthCore.Application\AuthCore.Application.csproj" />
     <ProjectReference Include="..\AuthCore.Infrastructure\AuthCore.Infrastructure.csproj" />
     <ProjectReference Include="..\AuthCore.Persistence\AuthCore.Persistence.csproj" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <Folder Include="Logs\" />
   </ItemGroup>
 
 </Project>

--- a/AuthCore.API/appsettings.Development.json
+++ b/AuthCore.API/appsettings.Development.json
@@ -1,8 +1,38 @@
 {
+  "JwtSettings": {
+    "Issuer": "AuthCoreDev",
+    "Audience": "AuthCoreDevClient"
+  },
+  "Identity": {
+    "DefaultUserRole": "User"
+  },
+  "Redis": {
+    "ConnectionString": "192.168.1.252:6379"
+  },
   "Logging": {
     "LogLevel": {
-      "Default": "Information",
-      "Microsoft.AspNetCore": "Warning"
+      "Default": "Debug",
+      "Microsoft": "Information",
+      "Microsoft.AspNetCore": "Debug",
+      "System": "Information"
     }
-  }
+  },
+  "Serilog": {
+    "MinimumLevel": {
+      "Default": "Debug",
+      "Override": {
+        "Microsoft": "Information",
+        "System": "Information"
+      }
+    },
+    "WriteTo": [
+      {
+        "Name": "Console"
+      }
+    ],
+    "Properties": {
+      "Environment": "Development"
+    }
+  },
+  "AllowedHosts": "*"
 }

--- a/AuthCore.API/appsettings.json
+++ b/AuthCore.API/appsettings.json
@@ -7,15 +7,17 @@
     "DefaultUserRole": "User"
   },
   "Redis": {
-    "ConnectionString": "192.168.1.252:6379"
+    "ConnectionString": "127.0.0.1:6379"
   },
   "Logging": {
     "LogLevel": {
-      "Default": "Warning"
+      "Default": "Warning",
+      "Microsoft": "Warning",
+      "Microsoft.AspNetCore": "Warning",
+      "System": "Warning"
     }
   },
   "Serilog": {
-    "Using": [ "Serilog.Sinks.Console", "Serilog.Sinks.File" ],
     "MinimumLevel": {
       "Default": "Information",
       "Override": {
@@ -25,9 +27,6 @@
     },
     "WriteTo": [
       {
-        "Name": "Console"
-      },
-      {
         "Name": "File",
         "Args": {
           "path": "Logs/log-.txt",
@@ -36,9 +35,8 @@
         }
       }
     ],
-    "Enrich": [ "FromLogContext", "WithMachineName", "WithThreadId" ],
     "Properties": {
-      "Application": "AuthCore.API"
+      "Environment": "Production"
     }
   },
   "AllowedHosts": "*"

--- a/AuthCore.Tests.Integration/Fixtures/CustomWebApplicationFactory.cs
+++ b/AuthCore.Tests.Integration/Fixtures/CustomWebApplicationFactory.cs
@@ -14,6 +14,8 @@ namespace AuthCore.Tests.Integration.Fixtures
 
         public CustomWebApplicationFactory()
         {
+            Environment.SetEnvironmentVariable("ASPNETCORE_ENVIRONMENT", "Test");
+
             _connection = new SqliteConnection("DataSource=:memory:");
 
             // Инициализация базы данных при создании фабрики


### PR DESCRIPTION
## What

Configured the use of environment-specific configuration files

## Why

To support CI/CD in GitHub Actions and load the appropriate settings during deployment

## How to test

No specific testing required. Verify the configuration files on the server after deployment (e.g., `appsettings.Production.json`)

---

Closes #
