### PR TITLE
feat(tests): add EmailNotificationSender unit tests and fix nullable …

### DIFF
--- a/AuthCore.Tests.Unit/API/Extensions/ResultExtensionsTests.cs
+++ b/AuthCore.Tests.Unit/API/Extensions/ResultExtensionsTests.cs
@@ -36,9 +36,9 @@ namespace AuthCore.Tests.Unit.API.Extensions
                 x => x.Log(
                     LogLevel.Information,
                     It.IsAny<EventId>(),
-                    It.Is<It.IsAnyType>((v, t) => v.ToString().Contains("Request succeeded")),
+                    It.Is<It.IsAnyType>((v, t) => v.ToString()!.Contains("Request succeeded")),
                     It.IsAny<Exception>(),
-                    It.IsAny<Func<It.IsAnyType, Exception, string>>()
+                    It.IsAny<Func<It.IsAnyType, Exception?, string>>()
                 ),
                 Times.Once
             );
@@ -60,7 +60,7 @@ namespace AuthCore.Tests.Unit.API.Extensions
                 x => x.Log(
                     LogLevel.Information,
                     It.IsAny<EventId>(),
-                    It.Is<It.IsAnyType>((v, t) => v.ToString().Contains("Request succeeded")),
+                    It.Is<It.IsAnyType>((v, t) => v.ToString()!.Contains("Request succeeded")),
                     It.IsAny<Exception>(),
                     It.IsAny<Func<It.IsAnyType, Exception?, string>>()
                 ),
@@ -136,7 +136,7 @@ namespace AuthCore.Tests.Unit.API.Extensions
                 x => x.Log(
                     LogLevel.Information,
                     It.IsAny<EventId>(),
-                    It.Is<It.IsAnyType>((v, t) => v.ToString().Contains("Request succeeded with data: TestData")),
+                    It.Is<It.IsAnyType>((v, t) => v.ToString()!.Contains("Request succeeded with data: TestData")),
                     null,
                     It.IsAny<Func<It.IsAnyType, Exception?, string>>()
                 ),

--- a/AuthCore.Tests.Unit/Infrastructure/Notifications/Senders/EmailNotificationSenderTests.cs
+++ b/AuthCore.Tests.Unit/Infrastructure/Notifications/Senders/EmailNotificationSenderTests.cs
@@ -1,0 +1,91 @@
+﻿using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Moq;
+using AuthCore.Application.Common.Settings;
+using AuthCore.Infrastructure.Notifications.Models;
+using AuthCore.Infrastructure.Notifications.Senders;
+
+namespace AuthCore.Tests.Unit.Infrastructure.Notifications.Senders
+{
+    public class EmailNotificationSenderTests
+    {
+        private readonly Mock<IOptionsMonitor<EmailSettings>> _settingsMock;
+        private readonly Mock<ILogger<EmailNotificationSender>> _loggerMock;
+
+        public EmailNotificationSenderTests()
+        {
+            _settingsMock = new Mock<IOptionsMonitor<EmailSettings>>();
+            _loggerMock = new Mock<ILogger<EmailNotificationSender>>();
+        }
+
+        [Theory]
+        [InlineData("smtp.test.com", 587, "from@test.com")]
+        [InlineData("smtp.example.com", 2525, "from@example.com")]
+        public async Task SendAsync_WithVariousValidSettings_ThrowsOnConnectionFailure(string host, int port, string from)
+        {
+            // Arrange
+            var settings = new EmailSettings
+            {
+                Host = host,
+                Port = port,
+                Username = "user",
+                Password = "pass",
+                From = from,
+                UseSsl = true
+            };
+            _settingsMock.Setup(x => x.CurrentValue).Returns(settings);
+
+            var sender = new EmailNotificationSender(_settingsMock.Object, _loggerMock.Object);
+
+            var message = new NotificationMessage
+            {
+                Recipient = "to@example.com",
+                Subject = "Subject",
+                Body = "<b>Body</b>"
+            };
+
+            // Act & Assert
+            await Assert.ThrowsAnyAsync<InvalidOperationException>(() =>
+                sender.SendAsync(message, CancellationToken.None));
+        }
+
+        [Fact]
+        public async Task SendAsync_SmtpThrows_LogsAndThrowsInvalidOperationException()
+        {
+            // Arrange
+            var settings = new EmailSettings
+            {
+                Host = "invalid",
+                Port = 25,
+                Username = "user",
+                Password = "pass",
+                From = "from@test.com",
+                UseSsl = false
+            };
+            _settingsMock.Setup(x => x.CurrentValue).Returns(settings);
+
+            var sender = new EmailNotificationSender(_settingsMock.Object, _loggerMock.Object);
+
+            var message = new NotificationMessage
+            {
+                Recipient = "to@test.com",
+                Subject = "Test",
+                Body = "Body"
+            };
+
+            // Act & Assert
+            var ex = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+                sender.SendAsync(message, CancellationToken.None));
+
+            Assert.Contains("Failed to send email notification", ex.Message);
+            _loggerMock.Verify(
+                l => l.Log(
+                    LogLevel.Error,
+                    It.IsAny<EventId>(),
+                    It.Is<It.IsAnyType>((v, t) => v.ToString()!.Contains("Failed to send email notification")),
+                    It.IsAny<Exception>(),
+                    It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+                Times.Once);
+        }
+    }
+}


### PR DESCRIPTION

## What

Added unit tests for EmailNotificationSender to cover connection failures and error logging. Made minor adjustments in existing tests (including logger verifications) to resolve nullable reference warnings and improve code safety.

## Why

These changes increase test coverage for the email notification sending logic and ensure that error handling and logging are properly verified. Fixing nullable warnings improves code reliability and maintainability.

## How to test

•	Run all unit tests in the solution.
•	Ensure that tests in AuthCore.Tests.Unit.Infrastructure.Notifications.Senders.EmailNotificationSenderTests pass without warnings.
•	Review test output to confirm that error scenarios and logger invocations are correctly handled.

## Security considerations

No security risks introduced. The changes are limited to unit tests and do not affect production code or sensitive data handling.

---

Closes #
