### PR TITLE
Feature/registration methods

### DIFF
--- a/AuthCore.Application/DTOs/IdentityType.cs
+++ b/AuthCore.Application/DTOs/IdentityType.cs
@@ -1,0 +1,22 @@
+﻿namespace AuthCore.Application.DTOs
+{
+    public enum IdentityType
+    {
+        /// <summary>
+        /// Email
+        /// </summary>
+        Email,
+        /// <summary>
+        /// Phone
+        /// </summary>
+        Phone,
+        /// <summary>
+        /// Telegram
+        /// </summary>
+        Telegram,
+        /// <summary>
+        /// WhatsApp
+        /// </summary>
+        WhatsApp
+    }
+}

--- a/AuthCore.Application/DTOs/LoginRequest.cs
+++ b/AuthCore.Application/DTOs/LoginRequest.cs
@@ -6,13 +6,18 @@
     public record LoginRequest
      {
         /// <summary>
-        /// The user's email address
+        /// The type of identifier used for login
         /// </summary>
-        public string Email { get; init; } = string.Empty;
+        public IdentityType IdentityType { get; init; }
 
         /// <summary>
-        /// The user's password
+        /// The identifier value (email, phone, messenger ID)
         /// </summary>
-        public string Password { get; init; } = string.Empty;
-     };
+        public string Identifier { get; init; } = string.Empty;
+
+        /// <summary>
+        /// The user's password (if applicable for this login type)
+        /// </summary>
+        public string? Password { get; init; }
+    };
 }

--- a/AuthCore.Application/DTOs/RegisterRequest.cs
+++ b/AuthCore.Application/DTOs/RegisterRequest.cs
@@ -6,13 +6,19 @@
     public record RegisterRequest
     {
         /// <summary>
-        /// The user's email address
+        /// The type of identifier used for registration
         /// </summary>
-        public string Email { get; init; } = string.Empty;
+        public IdentityType IdentityType { get; init; }
 
         /// <summary>
-        /// The user's password
+        /// The identifier value (email, phone, messenger ID)
         /// </summary>
-        public string Password { get; init; } = string.Empty;
+        public string Identifier { get; init; } = string.Empty;
+
+
+        /// <summary>
+        /// The user's password (if applicable for this registration type)
+        /// </summary>
+        public string? Password { get; init; }
     }
 }

--- a/AuthCore.Application/Services/AuthService.cs
+++ b/AuthCore.Application/Services/AuthService.cs
@@ -44,8 +44,17 @@ namespace AuthCore.Application.Services
                     break;
 
                 case IdentityType.Telegram:
-                    user.TelegramId = long.Parse(request.Identifier);
-                    user.UserName = $"telegram_{request.Identifier}";
+                    if (long.TryParse(request.Identifier, out var telegramId))
+                    {
+                        user.TelegramId = telegramId;
+                        user.UserName = $"telegram_{telegramId}";
+                    }
+                    else
+                    {
+                        logger.LogWarning("Telegram identifier is not numeric: {Identifier}", request.Identifier);
+                        user.TelegramId = null; // Or handle as appropriate for your application
+                        user.UserName = $"telegram_{request.Identifier}";
+                    }
                     break;
 
                 case IdentityType.WhatsApp:

--- a/AuthCore.Application/Validation/LoginRequestValidator.cs
+++ b/AuthCore.Application/Validation/LoginRequestValidator.cs
@@ -1,6 +1,5 @@
 ﻿using AuthCore.Application.DTOs;
 using FluentValidation;
-using System.Text.RegularExpressions;
 
 namespace AuthCore.Application.Validation
 {
@@ -60,13 +59,7 @@ namespace AuthCore.Application.Validation
 
         private bool BeValidTelegramId(string id)
         {
-            // Telegram ID can be numeric or username
-            return !string.IsNullOrEmpty(id) && (
-                // Numeric ID
-                long.TryParse(id, out _) ||
-                // Username (without @, 5-32 chars, letters, numbers and underscores)
-                Regex.IsMatch(id, @"^[a-zA-Z0-9_]{5,32}$")
-            );
+            return TelegramIdValidator.IsValid(id);
         }
     }
 }

--- a/AuthCore.Application/Validation/LoginRequestValidator.cs
+++ b/AuthCore.Application/Validation/LoginRequestValidator.cs
@@ -1,20 +1,72 @@
-﻿using FluentValidation;
-using AuthCore.Application.DTOs;
+﻿using AuthCore.Application.DTOs;
+using FluentValidation;
+using System.Text.RegularExpressions;
 
 namespace AuthCore.Application.Validation
 {
     public class LoginRequestValidator : AbstractValidator<LoginRequest>
-
     {
         public LoginRequestValidator()
         {
-            RuleFor(x => x.Email)
-                .NotEmpty()
-                .EmailAddress();
+            RuleFor(x => x.IdentityType)
+                .IsInEnum()
+                .WithMessage("Invalid identifier type");
 
-            RuleFor(x => x.Password)
+            RuleFor(x => x.Identifier)
                 .NotEmpty()
-                .MinimumLength(6);
+                .WithMessage("Identifier cannot be empty");
+
+            // Conditional validation based on identifier type
+            When(x => x.IdentityType == IdentityType.Email, () => {
+                RuleFor(x => x.Identifier)
+                    .EmailAddress()
+                    .WithMessage("Invalid email format");
+
+                RuleFor(x => x.Password)
+                    .NotEmpty()
+                    .WithMessage("Password is required for email login")
+                    .MinimumLength(10)
+                    .WithMessage("Password must be at least 10 characters long");
+            });
+
+            When(x => x.IdentityType == IdentityType.Phone, () => {
+                RuleFor(x => x.Identifier)
+                    .Matches(@"^\+?[1-9]\d{1,14}$")
+                    .WithMessage("Invalid phone number format. Use international format");
+
+                RuleFor(x => x.Password)
+                    .NotEmpty()
+                    .WithMessage("Password is required for phone login")
+                    .MinimumLength(10)
+                    .WithMessage("Password must be at least 10 characters long");
+            });
+
+            When(x => x.IdentityType == IdentityType.Telegram, () => {
+                RuleFor(x => x.Identifier)
+                    .Must(BeValidTelegramId)
+                    .WithMessage("Invalid Telegram ID format");
+
+                // Password is not required for Telegram
+            });
+
+            When(x => x.IdentityType == IdentityType.WhatsApp, () => {
+                RuleFor(x => x.Identifier)
+                    .Matches(@"^\+?[1-9]\d{1,14}$")
+                    .WithMessage("Invalid WhatsApp number format. Use international format");
+
+                // Password is not required for WhatsApp
+            });
+        }
+
+        private bool BeValidTelegramId(string id)
+        {
+            // Telegram ID can be numeric or username
+            return !string.IsNullOrEmpty(id) && (
+                // Numeric ID
+                long.TryParse(id, out _) ||
+                // Username (without @, 5-32 chars, letters, numbers and underscores)
+                Regex.IsMatch(id, @"^[a-zA-Z0-9_]{5,32}$")
+            );
         }
     }
 }

--- a/AuthCore.Application/Validation/RegisterRequestValidator.cs
+++ b/AuthCore.Application/Validation/RegisterRequestValidator.cs
@@ -1,5 +1,6 @@
-﻿using FluentValidation;
-using AuthCore.Application.DTOs;
+﻿using AuthCore.Application.DTOs;
+using FluentValidation;
+using System.Text.RegularExpressions;
 
 namespace AuthCore.Application.Validation
 {
@@ -7,13 +8,75 @@ namespace AuthCore.Application.Validation
     {
         public RegisterRequestValidator()
         {
-            RuleFor(x => x.Email)
-                .NotEmpty()
-                .EmailAddress();
+            RuleFor(x => x.IdentityType)
+                .IsInEnum()
+                .WithMessage("Invalid identifier type");
 
-            RuleFor(x => x.Password)
+            RuleFor(x => x.Identifier)
                 .NotEmpty()
-                .MinimumLength(6);
+                .WithMessage("Identifier cannot be empty");
+
+            // Conditional validation based on identifier type
+            When(x => x.IdentityType == IdentityType.Email, () => {
+                RuleFor(x => x.Identifier)
+                    .EmailAddress()
+                    .WithMessage("Invalid email format");
+
+                RuleFor(x => x.Password)
+                    .NotEmpty()
+                    .WithMessage("Password is required for email registration")
+                    .MinimumLength(10)
+                    .WithMessage("Password must be at least 10 characters long");
+            });
+
+            When(x => x.IdentityType == IdentityType.Phone, () => {
+                RuleFor(x => x.Identifier)
+                    .Matches(@"^\+?[1-9]\d{1,14}$")
+                    .WithMessage("Invalid phone number format. Use international format");
+
+                RuleFor(x => x.Password)
+                    .NotEmpty()
+                    .WithMessage("Password is required for phone registration")
+                    .MinimumLength(10)
+                    .WithMessage("Password must be at least 10 characters long");
+            });
+
+            When(x => x.IdentityType == IdentityType.Telegram, () => {
+                RuleFor(x => x.Identifier)
+                    .Must(BeValidTelegramId)
+                    .WithMessage("Invalid Telegram ID format");
+
+                // Password is optional for Telegram registrations
+                When(x => !string.IsNullOrEmpty(x.Password), () => {
+                    RuleFor(x => x.Password)
+                        .MinimumLength(10)
+                        .WithMessage("If provided, password must be at least 10 characters long");
+                });
+            });
+
+            When(x => x.IdentityType == IdentityType.WhatsApp, () => {
+                RuleFor(x => x.Identifier)
+                    .Matches(@"^\+?[1-9]\d{1,14}$")
+                    .WithMessage("Invalid WhatsApp number format. Use international format");
+
+                // Password is optional for WhatsApp registrations
+                When(x => !string.IsNullOrEmpty(x.Password), () => {
+                    RuleFor(x => x.Password)
+                        .MinimumLength(10)
+                        .WithMessage("If provided, password must be at least 10 characters long");
+                });
+            });
+        }
+
+        private bool BeValidTelegramId(string id)
+        {
+            // Telegram ID can be numeric or username
+            return !string.IsNullOrEmpty(id) && (
+                // Numeric ID
+                long.TryParse(id, out _) ||
+                // Username (without @, 5-32 chars, letters, numbers and underscores)
+                Regex.IsMatch(id, @"^[a-zA-Z0-9_]{5,32}$")
+            );
         }
     }
 }

--- a/AuthCore.Application/Validation/RegisterRequestValidator.cs
+++ b/AuthCore.Application/Validation/RegisterRequestValidator.cs
@@ -1,6 +1,5 @@
 ﻿using AuthCore.Application.DTOs;
 using FluentValidation;
-using System.Text.RegularExpressions;
 
 namespace AuthCore.Application.Validation
 {
@@ -70,13 +69,7 @@ namespace AuthCore.Application.Validation
 
         private bool BeValidTelegramId(string id)
         {
-            // Telegram ID can be numeric or username
-            return !string.IsNullOrEmpty(id) && (
-                // Numeric ID
-                long.TryParse(id, out _) ||
-                // Username (without @, 5-32 chars, letters, numbers and underscores)
-                Regex.IsMatch(id, @"^[a-zA-Z0-9_]{5,32}$")
-            );
+            return TelegramIdValidator.IsValid(id);
         }
     }
 }

--- a/AuthCore.Application/Validation/TelegramIdValidator.cs
+++ b/AuthCore.Application/Validation/TelegramIdValidator.cs
@@ -1,0 +1,21 @@
+﻿using System.Text.RegularExpressions;
+
+namespace AuthCore.Application.Validation
+{
+    public static partial class TelegramIdValidator
+    {
+        public static bool IsValid(string id)
+        {
+            // Telegram ID can be numeric or username
+            return !string.IsNullOrEmpty(id) && (
+                // Numeric ID
+                long.TryParse(id, out _) ||
+                // Username (without @, 5-32 chars, letters, numbers and underscores)
+                TelegramUsernameRegex().IsMatch(id)
+            );
+        }
+
+        [GeneratedRegex(@"^[a-zA-Z0-9_]{5,32}$")]
+        private static partial Regex TelegramUsernameRegex();
+    }
+}

--- a/AuthCore.Persistence/Entities/ApplicationUser.cs
+++ b/AuthCore.Persistence/Entities/ApplicationUser.cs
@@ -1,9 +1,21 @@
 ﻿namespace AuthCore.Persistence.Entities
 {
     using Microsoft.AspNetCore.Identity;
+    using System.ComponentModel.DataAnnotations;
 
     public class ApplicationUser : IdentityUser
     {
+        /// <summary>
+        /// Идентификатор пользователя Telegram (числовой)
+        /// </summary>
+        public long? TelegramId { get; set; }
+
+        /// <summary>
+        /// Идентификатор пользователя WhatsApp (обычно номер телефона)
+        /// </summary>
+        [StringLength(25)]
+        public string? WhatsAppId { get; set; }
+
         public ICollection<RefreshToken> RefreshTokens { get; set; } = [];
     }
 }

--- a/AuthCore.Tests.Integration/Auth/LoginTests.cs
+++ b/AuthCore.Tests.Integration/Auth/LoginTests.cs
@@ -21,7 +21,8 @@ namespace AuthCore.Tests.Integration.Auth
             // Arrange
             var loginRequest = new LoginRequest
             {
-                Email = "testuser@example.com",
+                IdentityType = IdentityType.Email,
+                Identifier = "testuser@example.com",
                 Password = "ValidPassword123!"
             };
 
@@ -30,7 +31,7 @@ namespace AuthCore.Tests.Integration.Auth
             {
                 var userManager = scope.ServiceProvider.GetRequiredService<UserManager<ApplicationUser>>();
 
-                var user = new ApplicationUser { UserName = loginRequest.Email, Email = loginRequest.Email };
+                var user = new ApplicationUser { UserName = loginRequest.Identifier, Email = loginRequest.Identifier };
                 await userManager.CreateAsync(user, loginRequest.Password);
             }
 
@@ -51,7 +52,8 @@ namespace AuthCore.Tests.Integration.Auth
             // Arrange
             var loginRequest = new LoginRequest
             {
-                Email = "invaliduser@example.com",
+                IdentityType = IdentityType.Email,
+                Identifier = "invaliduser@example.com",
                 Password = "WrongPassword123!"
             };
 
@@ -68,7 +70,8 @@ namespace AuthCore.Tests.Integration.Auth
             // Arrange
             var loginRequest = new LoginRequest
             {
-                Email = "", // Invalid email
+                IdentityType = IdentityType.Email,
+                Identifier = "", // Invalid email
                 Password = ""
             };
 

--- a/AuthCore.Tests.Integration/Auth/LoginTests.cs
+++ b/AuthCore.Tests.Integration/Auth/LoginTests.cs
@@ -81,5 +81,100 @@ namespace AuthCore.Tests.Integration.Auth
             // Assert
             response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
         }
+
+        // Добавляем новые тесты для входа через разные каналы идентификации
+        [Fact]
+        public async Task Login_ShouldReturn200_WhenUsingPhoneNumber()
+        {
+            // Arrange
+            var loginRequest = new LoginRequest
+            {
+                IdentityType = IdentityType.Phone,
+                Identifier = "+12345678901",
+                Password = "ValidPassword123!"
+            };
+
+            // Добавляем пользователя в базу данных
+            using (var scope = factory.Services.CreateScope())
+            {
+                var userManager = scope.ServiceProvider.GetRequiredService<UserManager<ApplicationUser>>();
+
+                var user = new ApplicationUser
+                {
+                    UserName = "phone_user",
+                    Email = "phone_user@example.com",
+                    PhoneNumber = loginRequest.Identifier
+                };
+                await userManager.CreateAsync(user, loginRequest.Password);
+            }
+
+            // Act
+            var response = await _client.PostAsJsonAsync("/api/auth/login", loginRequest);
+
+            // Assert
+            response.StatusCode.Should().Be(HttpStatusCode.OK);
+            var authResponse = await response.Content.ReadFromJsonAsync<AuthResponse>();
+            authResponse.Should().NotBeNull();
+            authResponse.AccessToken.Should().NotBeNullOrEmpty();
+            authResponse.RefreshToken.Should().NotBeNullOrEmpty();
+        }
+
+        [Fact]
+        public async Task Login_ShouldReturn200_WhenUsingTelegramId()
+        {
+            // Arrange
+            var loginRequest = new LoginRequest
+            {
+                IdentityType = IdentityType.Telegram,
+                Identifier = "123",
+                Password = null // Пароль не требуется для Telegram
+            };
+
+            // Регистрируем пользователя через Telegram
+            var registerRequest = new RegisterRequest
+            {
+                IdentityType = IdentityType.Telegram,
+                Identifier = loginRequest.Identifier,
+            };
+            await _client.PostAsJsonAsync("/api/auth/register", registerRequest);
+
+            // Act
+            var response = await _client.PostAsJsonAsync("/api/auth/login", loginRequest);
+
+            // Assert
+            response.StatusCode.Should().Be(HttpStatusCode.OK);
+            var authResponse = await response.Content.ReadFromJsonAsync<AuthResponse>();
+            authResponse.Should().NotBeNull();
+            authResponse.AccessToken.Should().NotBeNullOrEmpty();
+        }
+
+        [Fact]
+        public async Task Login_ShouldReturn200_WhenUsingWhatsAppNumber()
+        {
+            // Arrange
+            var loginRequest = new LoginRequest
+            {
+                IdentityType = IdentityType.WhatsApp,
+                Identifier = "+12345678901",
+                Password = null // Пароль не требуется для WhatsApp
+            };
+
+            // Регистрируем пользователя через WhatsApp
+            var registerRequest = new RegisterRequest
+            {
+                IdentityType = IdentityType.WhatsApp,
+                Identifier = loginRequest.Identifier,
+            };
+            await _client.PostAsJsonAsync("/api/auth/register", registerRequest);
+
+            // Act
+            var response = await _client.PostAsJsonAsync("/api/auth/login", loginRequest);
+
+            // Assert
+            response.StatusCode.Should().Be(HttpStatusCode.OK);
+            var authResponse = await response.Content.ReadFromJsonAsync<AuthResponse>();
+            authResponse.Should().NotBeNull();
+            authResponse.AccessToken.Should().NotBeNullOrEmpty();
+        }
     }
 }

--- a/AuthCore.Tests.Integration/Auth/LogoutTests.cs
+++ b/AuthCore.Tests.Integration/Auth/LogoutTests.cs
@@ -22,7 +22,8 @@ namespace AuthCore.Tests.Integration.Auth
             // Arrange
             var registerRequest = new RegisterRequest
             {
-                Email = "logoutuser@example.com",
+                IdentityType = IdentityType.Email,
+                Identifier = "logoutuser@example.com",
                 Password = "SecurePassword123!"
             };
 
@@ -50,7 +51,8 @@ namespace AuthCore.Tests.Integration.Auth
             // Arrange
             var registerRequest = new RegisterRequest
             {
-                Email = "invalidlogout@example.com",
+                IdentityType = IdentityType.Email,
+                Identifier = "invalidlogout@example.com",
                 Password = "StrongPass!456"
             };
 

--- a/AuthCore.Tests.Integration/Auth/RefreshTests.cs
+++ b/AuthCore.Tests.Integration/Auth/RefreshTests.cs
@@ -18,7 +18,8 @@ namespace AuthCore.Tests.Integration.Auth
             // Arrange
             var registerRequest = new RegisterRequest
             {
-                Email = "newuser@example.com",
+                IdentityType = IdentityType.Email,
+                Identifier = "newuser@example.com",
                 Password = "ValidPassword123!"
             };
 
@@ -49,14 +50,16 @@ namespace AuthCore.Tests.Integration.Auth
             // Arrange
             var loginRequest = new LoginRequest
             {
-                Email = "testuser@example.com",
+                IdentityType = IdentityType.Email,
+                Identifier = "testuser@example.com",
                 Password = "ValidPassword123!"
             };
 
             // Предварительная регистрация пользователя
             await _client.PostAsJsonAsync("/api/auth/register", new RegisterRequest
             {
-                Email = loginRequest.Email,
+                IdentityType = IdentityType.Email,
+                Identifier = loginRequest.Identifier,
                 Password = loginRequest.Password
             });
 
@@ -88,7 +91,8 @@ namespace AuthCore.Tests.Integration.Auth
 
             var registerRequest = new RegisterRequest
             {
-                Email = "olduser@example.com",
+                IdentityType = IdentityType.Email,
+                Identifier = "olduser@example.com",
                 Password = "ValidPassword123!"
             };
 

--- a/AuthCore.Tests.Integration/Auth/RegisterTests.cs
+++ b/AuthCore.Tests.Integration/Auth/RegisterTests.cs
@@ -21,7 +21,8 @@ namespace AuthCore.Tests.Integration.Auth
             // Arrange
             var registerRequest = new RegisterRequest
             {
-                Email = "newuser@example.com",
+                IdentityType = IdentityType.Email,
+                Identifier = "newuser@example.com",
                 Password = "StrongPassword123!"
             };
 
@@ -42,7 +43,8 @@ namespace AuthCore.Tests.Integration.Auth
             // Arrange
             var registerRequest = new RegisterRequest
             {
-                Email = "", // Invalid email
+                IdentityType = IdentityType.Email,
+                Identifier = "", // Invalid email
                 Password = "" // Invalid password
             };
 
@@ -59,7 +61,8 @@ namespace AuthCore.Tests.Integration.Auth
             // Arrange
             var registerRequest = new RegisterRequest
             {
-                Email = "existinguser@example.com",
+                IdentityType = IdentityType.Email,
+                Identifier = "existinguser@example.com",
                 Password = "StrongPassword123!"
             };
 
@@ -68,7 +71,7 @@ namespace AuthCore.Tests.Integration.Auth
             {
                 var userManager = scope.ServiceProvider.GetRequiredService<UserManager<ApplicationUser>>();
 
-                var user = new ApplicationUser { UserName = registerRequest.Email, Email = registerRequest.Email };
+                var user = new ApplicationUser { UserName = registerRequest.Identifier, Email = registerRequest.Identifier };
                 await userManager.CreateAsync(user, registerRequest.Password);
             }
 

--- a/AuthCore.Tests.Integration/Auth/RegisterTests.cs
+++ b/AuthCore.Tests.Integration/Auth/RegisterTests.cs
@@ -81,5 +81,72 @@ namespace AuthCore.Tests.Integration.Auth
             // Assert
             response.StatusCode.Should().Be(HttpStatusCode.Conflict);
         }
+
+        // Добавляем новые тесты для регистрации через разные каналы идентификации
+        [Fact]
+        public async Task Register_ShouldReturn201_WhenRegisteringWithPhone()
+        {
+            // Arrange
+            var registerRequest = new RegisterRequest
+            {
+                IdentityType = IdentityType.Phone,
+                Identifier = "+12345678901",
+                Password = "StrongPassword123!"
+            };
+
+            // Act
+            var response = await _client.PostAsJsonAsync("/api/auth/register", registerRequest);
+
+            // Assert
+            response.StatusCode.Should().Be(HttpStatusCode.Created);
+            var authResponse = await response.Content.ReadFromJsonAsync<AuthResponse>();
+            authResponse.Should().NotBeNull();
+            authResponse.AccessToken.Should().NotBeNullOrEmpty();
+            authResponse.RefreshToken.Should().NotBeNullOrEmpty();
+        }
+
+        [Fact]
+        public async Task Register_ShouldReturn201_WhenRegisteringWithTelegram()
+        {
+            // Arrange
+            var registerRequest = new RegisterRequest
+            {
+                IdentityType = IdentityType.Telegram,
+                Identifier = "123",
+                Password = null // Пароль необязателен
+            };
+
+            // Act
+            var response = await _client.PostAsJsonAsync("/api/auth/register", registerRequest);
+
+            // Assert
+            response.StatusCode.Should().Be(HttpStatusCode.Created);
+            var authResponse = await response.Content.ReadFromJsonAsync<AuthResponse>();
+            authResponse.Should().NotBeNull();
+            authResponse.AccessToken.Should().NotBeNullOrEmpty();
+            authResponse.RefreshToken.Should().NotBeNullOrEmpty();
+        }
+
+        [Fact]
+        public async Task Register_ShouldReturn201_WhenRegisteringWithWhatsApp()
+        {
+            // Arrange
+            var registerRequest = new RegisterRequest
+            {
+                IdentityType = IdentityType.WhatsApp,
+                Identifier = "+12345678901",
+                Password = null // Пароль необязателен
+            };
+
+            // Act
+            var response = await _client.PostAsJsonAsync("/api/auth/register", registerRequest);
+
+            // Assert
+            response.StatusCode.Should().Be(HttpStatusCode.Created);
+            var authResponse = await response.Content.ReadFromJsonAsync<AuthResponse>();
+            authResponse.Should().NotBeNull();
+            authResponse.AccessToken.Should().NotBeNullOrEmpty();
+            authResponse.RefreshToken.Should().NotBeNullOrEmpty();
+        }
     }
 }

--- a/AuthCore.Tests.Unit/Application/Services/AuthServiceTests.cs
+++ b/AuthCore.Tests.Unit/Application/Services/AuthServiceTests.cs
@@ -56,7 +56,7 @@ namespace AuthCore.Tests.Unit.Application.Services
         public async Task RegisterAsync_Success_ReturnsOk()
         {
             // Arrange
-            var request = new RegisterRequest { Email = "test@example.com", Password = "Password123!" };
+            var request = new RegisterRequest { IdentityType = IdentityType.Email, Identifier = "test@example.com", Password = "Password123!" };
             _userManagerMock.Setup(x => x.CreateAsync(It.IsAny<ApplicationUser>(), request.Password))
                 .ReturnsAsync(IdentityResult.Success);
 
@@ -95,7 +95,7 @@ namespace AuthCore.Tests.Unit.Application.Services
         public async Task RegisterAsync_Failure_ReturnsFail()
         {
             // Arrange
-            var request = new RegisterRequest { Email = "fail@example.com", Password = "BadPassword" };
+            var request = new RegisterRequest { IdentityType = IdentityType.Email, Identifier = "fail@example.com", Password = "BadPassword" };
             var identityErrors = new List<IdentityError>
                 { new() { Code = "DuplicateUserName", Description = "User already exists." } };
 
@@ -117,10 +117,10 @@ namespace AuthCore.Tests.Unit.Application.Services
         public async Task LoginAsync_Success_ReturnsOk()
         {
             // Arrange
-            var request = new LoginRequest { Email = "login@example.com", Password = "Password123!" };
-            var user = new ApplicationUser { Id = "userId", Email = request.Email };
+            var request = new LoginRequest { IdentityType = IdentityType.Email, Identifier = "login@example.com", Password = "Password123!" };
+            var user = new ApplicationUser { Id = "userId", Email = request.Identifier };
 
-            _userManagerMock.Setup(x => x.FindByEmailAsync(request.Email))
+            _userManagerMock.Setup(x => x.FindByEmailAsync(request.Identifier))
                 .ReturnsAsync(user);
 
             _signInManagerMock.Setup(x => x.CheckPasswordSignInAsync(user, request.Password, false))
@@ -153,8 +153,8 @@ namespace AuthCore.Tests.Unit.Application.Services
         public async Task LoginAsync_UserNotFound_ReturnsFail()
         {
             // Arrange
-            var request = new LoginRequest { Email = "notfound@example.com", Password = "Password123!" };
-            _userManagerMock.Setup(x => x.FindByEmailAsync(request.Email))
+            var request = new LoginRequest { IdentityType = IdentityType.Email, Identifier = "notfound@example.com", Password = "Password123!" };
+            _userManagerMock.Setup(x => x.FindByEmailAsync(request.Identifier))
                 .ReturnsAsync((ApplicationUser?)null);
 
             // Act

--- a/AuthCore.Tests.Unit/Application/Validation/LoginRequestValidatorTests.cs
+++ b/AuthCore.Tests.Unit/Application/Validation/LoginRequestValidatorTests.cs
@@ -1,7 +1,7 @@
-﻿using System.Globalization;
-using FluentValidation.TestHelper;
+﻿using AuthCore.Application.DTOs;
 using AuthCore.Application.Validation;
-using AuthCore.Application.DTOs;
+using FluentValidation.TestHelper;
+using System.Globalization;
 
 namespace AuthCore.Tests.Unit.Application.Validation
 {
@@ -84,6 +84,142 @@ namespace AuthCore.Tests.Unit.Application.Validation
             result.ShouldNotHaveValidationErrorFor(x => x.Identifier);
             result.ShouldNotHaveValidationErrorFor(x => x.Password);
         }
+
+        // Новые тесты для телефона
+        [Fact]
+        public void Should_Have_Error_When_Phone_Format_Is_Invalid()
+        {
+            // Arrange
+            var model = new LoginRequest { IdentityType = IdentityType.Phone, Identifier = "invalid-phone", Password = "ValidPassword123" };
+
+            // Act
+            var result = _validator.TestValidate(model);
+
+            // Assert
+            result.ShouldHaveValidationErrorFor(x => x.Identifier)
+                .WithErrorMessage("Invalid phone number format. Use international format");
+        }
+
+        [Fact]
+        public void Should_Not_Have_Error_When_Phone_Format_Is_Valid()
+        {
+            // Arrange
+            var model = new LoginRequest { IdentityType = IdentityType.Phone, Identifier = "+12345678901", Password = "ValidPassword123" };
+
+            // Act
+            var result = _validator.TestValidate(model);
+
+            // Assert
+            result.ShouldNotHaveValidationErrorFor(x => x.Identifier);
+        }
+
+        [Fact]
+        public void Should_Have_Error_When_Phone_Password_Is_Empty()
+        {
+            // Arrange
+            var model = new LoginRequest { IdentityType = IdentityType.Phone, Identifier = "+12345678901", Password = string.Empty };
+
+            // Act
+            var result = _validator.TestValidate(model);
+
+            // Assert
+            result.ShouldHaveValidationErrorFor(x => x.Password)
+                .WithErrorMessage("Password is required for phone login");
+        }
+
+        // Новые тесты для Telegram
+        [Fact]
+        public void Should_Have_Error_When_Telegram_Id_Is_Invalid()
+        {
+            // Arrange
+            var model = new LoginRequest { IdentityType = IdentityType.Telegram, Identifier = "inv", Password = "ValidPassword123" };
+
+            // Act
+            var result = _validator.TestValidate(model);
+
+            // Assert
+            result.ShouldHaveValidationErrorFor(x => x.Identifier)
+                .WithErrorMessage("Invalid Telegram ID format");
+        }
+
+        [Fact]
+        public void Should_Not_Have_Error_When_Telegram_Id_Is_Valid_Username()
+        {
+            // Arrange
+            var model = new LoginRequest { IdentityType = IdentityType.Telegram, Identifier = "username_123" };
+
+            // Act
+            var result = _validator.TestValidate(model);
+
+            // Assert
+            result.ShouldNotHaveValidationErrorFor(x => x.Identifier);
+        }
+
+        [Fact]
+        public void Should_Not_Have_Error_When_Telegram_Id_Is_Valid_Number()
+        {
+            // Arrange
+            var model = new LoginRequest { IdentityType = IdentityType.Telegram, Identifier = "12345678" };
+
+            // Act
+            var result = _validator.TestValidate(model);
+
+            // Assert
+            result.ShouldNotHaveValidationErrorFor(x => x.Identifier);
+        }
+
+        [Fact]
+        public void Should_Not_Require_Password_For_Telegram()
+        {
+            // Arrange
+            var model = new LoginRequest { IdentityType = IdentityType.Telegram, Identifier = "username_123", Password = string.Empty };
+
+            // Act
+            var result = _validator.TestValidate(model);
+
+            // Assert
+            result.ShouldNotHaveValidationErrorFor(x => x.Password);
+        }
+
+        // Новые тесты для WhatsApp
+        [Fact]
+        public void Should_Have_Error_When_WhatsApp_Number_Is_Invalid()
+        {
+            // Arrange
+            var model = new LoginRequest { IdentityType = IdentityType.WhatsApp, Identifier = "invalid-whatsapp" };
+
+            // Act
+            var result = _validator.TestValidate(model);
+
+            // Assert
+            result.ShouldHaveValidationErrorFor(x => x.Identifier)
+                .WithErrorMessage("Invalid WhatsApp number format. Use international format");
+        }
+
+        [Fact]
+        public void Should_Not_Have_Error_When_WhatsApp_Number_Is_Valid()
+        {
+            // Arrange
+            var model = new LoginRequest { IdentityType = IdentityType.WhatsApp, Identifier = "+12345678901" };
+
+            // Act
+            var result = _validator.TestValidate(model);
+
+            // Assert
+            result.ShouldNotHaveValidationErrorFor(x => x.Identifier);
+        }
+
+        [Fact]
+        public void Should_Not_Require_Password_For_WhatsApp()
+        {
+            // Arrange
+            var model = new LoginRequest { IdentityType = IdentityType.WhatsApp, Identifier = "+12345678901", Password = string.Empty };
+
+            // Act
+            var result = _validator.TestValidate(model);
+
+            // Assert
+            result.ShouldNotHaveValidationErrorFor(x => x.Password);
+        }
     }
 }
-

--- a/AuthCore.Tests.Unit/Application/Validation/LoginRequestValidatorTests.cs
+++ b/AuthCore.Tests.Unit/Application/Validation/LoginRequestValidatorTests.cs
@@ -19,69 +19,69 @@ namespace AuthCore.Tests.Unit.Application.Validation
         public void Should_Have_Error_When_Email_Is_Empty()
         {
             // Arrange
-            var model = new LoginRequest { Email = string.Empty, Password = "ValidPassword123" };
+            var model = new LoginRequest { IdentityType = IdentityType.Email, Identifier = string.Empty, Password = "ValidPassword123" };
 
             // Act
             var result = _validator.TestValidate(model);
 
             // Assert
-            result.ShouldHaveValidationErrorFor(x => x.Email)
-                .WithErrorMessage("'Email' must not be empty.");
+            result.ShouldHaveValidationErrorFor(x => x.Identifier)
+                .WithErrorMessage("Identifier cannot be empty");
         }
 
         [Fact]
         public void Should_Have_Error_When_Email_Is_Invalid()
         {
             // Arrange
-            var model = new LoginRequest { Email = "invalid-email", Password = "ValidPassword123" };
+            var model = new LoginRequest { IdentityType = IdentityType.Email, Identifier = "invalid-email", Password = "ValidPassword123" };
 
             // Act
             var result = _validator.TestValidate(model);
 
             // Assert
-            result.ShouldHaveValidationErrorFor(x => x.Email)
-                .WithErrorMessage("'Email' is not a valid email address.");
+            result.ShouldHaveValidationErrorFor(x => x.Identifier)
+                .WithErrorMessage("Invalid email format");
         }
 
         [Fact]
         public void Should_Have_Error_When_Password_Is_Empty()
         {
             // Arrange
-            var model = new LoginRequest { Email = "test@example.com", Password = string.Empty };
+            var model = new LoginRequest { IdentityType = IdentityType.Email, Identifier = "test@example.com", Password = string.Empty };
 
             // Act
             var result = _validator.TestValidate(model);
 
             // Assert
             result.ShouldHaveValidationErrorFor(x => x.Password)
-                .WithErrorMessage("'Password' must not be empty.");
+                .WithErrorMessage("Password is required for email login");
         }
 
         [Fact]
         public void Should_Have_Error_When_Password_Is_Too_Short()
         {
             // Arrange
-            var model = new LoginRequest { Email = "test@example.com", Password = "123" };
+            var model = new LoginRequest { IdentityType = IdentityType.Email, Identifier = "test@example.com", Password = "123" };
 
             // Act
             var result = _validator.TestValidate(model);
 
             // Assert
             result.ShouldHaveValidationErrorFor(x => x.Password)
-                .WithErrorMessage("The length of 'Password' must be at least 6 characters. You entered 3 characters.");
+                .WithErrorMessage("Password must be at least 10 characters long");
         }
 
         [Fact]
         public void Should_Not_Have_Error_When_Model_Is_Valid()
         {
             // Arrange
-            var model = new LoginRequest { Email = "test@example.com", Password = "ValidPassword123" };
+            var model = new LoginRequest { IdentityType = IdentityType.Email, Identifier = "test@example.com", Password = "ValidPassword123" };
 
             // Act
             var result = _validator.TestValidate(model);
 
             // Assert
-            result.ShouldNotHaveValidationErrorFor(x => x.Email);
+            result.ShouldNotHaveValidationErrorFor(x => x.Identifier);
             result.ShouldNotHaveValidationErrorFor(x => x.Password);
         }
     }

--- a/AuthCore.Tests.Unit/Application/Validation/RegisterRequestValidatorTests.cs
+++ b/AuthCore.Tests.Unit/Application/Validation/RegisterRequestValidatorTests.cs
@@ -20,69 +20,69 @@ namespace AuthCore.Tests.Unit.Application.Validation
         public void Should_Have_Error_When_Email_Is_Empty()
         {
             // Arrange
-            var model = new RegisterRequest { Email = string.Empty, Password = "ValidPassword123" };
+            var model = new RegisterRequest { IdentityType = IdentityType.Email, Identifier = string.Empty, Password = "ValidPassword123" };
 
             // Act
             var result = _validator.TestValidate(model);
 
             // Assert
-            result.ShouldHaveValidationErrorFor(x => x.Email)
-                .WithErrorMessage("'Email' must not be empty.");
+            result.ShouldHaveValidationErrorFor(x => x.Identifier)
+                .WithErrorMessage("Identifier cannot be empty");
         }
 
         [Fact]
         public void Should_Have_Error_When_Email_Is_Invalid()
         {
             // Arrange
-            var model = new RegisterRequest { Email = "invalid-email", Password = "ValidPassword123" };
+            var model = new RegisterRequest { IdentityType = IdentityType.Email, Identifier = "invalid-email", Password = "ValidPassword123" };
 
             // Act
             var result = _validator.TestValidate(model);
 
             // Assert
-            result.ShouldHaveValidationErrorFor(x => x.Email)
-                .WithErrorMessage("'Email' is not a valid email address.");
+            result.ShouldHaveValidationErrorFor(x => x.Identifier)
+                .WithErrorMessage("Invalid email format");
         }
 
         [Fact]
         public void Should_Have_Error_When_Password_Is_Empty()
         {
             // Arrange
-            var model = new RegisterRequest { Email = "test@example.com", Password = string.Empty };
+            var model = new RegisterRequest { IdentityType = IdentityType.Email, Identifier = "test@example.com", Password = string.Empty };
 
             // Act
             var result = _validator.TestValidate(model);
 
             // Assert
             result.ShouldHaveValidationErrorFor(x => x.Password)
-                .WithErrorMessage("'Password' must not be empty.");
+                .WithErrorMessage("Password is required for email registration");
         }
 
         [Fact]
         public void Should_Have_Error_When_Password_Is_Too_Short()
         {
             // Arrange
-            var model = new RegisterRequest { Email = "test@example.com", Password = "123" };
+            var model = new RegisterRequest { IdentityType = IdentityType.Email, Identifier = "test@example.com", Password = "123" };
 
             // Act
             var result = _validator.TestValidate(model);
 
             // Assert
             result.ShouldHaveValidationErrorFor(x => x.Password)
-                .WithErrorMessage("The length of 'Password' must be at least 6 characters. You entered 3 characters.");
+                .WithErrorMessage("Password must be at least 10 characters long");
         }
 
         [Fact]
         public void Should_Not_Have_Error_When_Model_Is_Valid()
         {
             // Arrange
-            var model = new RegisterRequest { Email = "test@example.com", Password = "ValidPassword123" };
+            var model = new RegisterRequest { IdentityType = IdentityType.Email, Identifier = "test@example.com", Password = "ValidPassword123" };
 
             // Act
             var result = _validator.TestValidate(model);
 
             // Assert
-            result.ShouldNotHaveValidationErrorFor(x => x.Email);
+            result.ShouldNotHaveValidationErrorFor(x => x.Identifier);
             result.ShouldNotHaveValidationErrorFor(x => x.Password);
         }
     }

--- a/AuthCore.Tests.Unit/Application/Validation/RegisterRequestValidatorTests.cs
+++ b/AuthCore.Tests.Unit/Application/Validation/RegisterRequestValidatorTests.cs
@@ -1,7 +1,7 @@
-﻿using System.Globalization;
-using FluentValidation.TestHelper;
+﻿using AuthCore.Application.DTOs;
 using AuthCore.Application.Validation;
-using AuthCore.Application.DTOs;
+using FluentValidation.TestHelper;
+using System.Globalization;
 
 namespace AuthCore.Tests.Unit.Application.Validation
 {
@@ -84,6 +84,171 @@ namespace AuthCore.Tests.Unit.Application.Validation
             // Assert
             result.ShouldNotHaveValidationErrorFor(x => x.Identifier);
             result.ShouldNotHaveValidationErrorFor(x => x.Password);
+        }
+
+        // Новые тесты для телефонного номера
+        [Fact]
+        public void Should_Have_Error_When_Phone_Format_Is_Invalid()
+        {
+            // Arrange
+            var model = new RegisterRequest { IdentityType = IdentityType.Phone, Identifier = "invalid-phone", Password = "ValidPassword123" };
+
+            // Act
+            var result = _validator.TestValidate(model);
+
+            // Assert
+            result.ShouldHaveValidationErrorFor(x => x.Identifier)
+                .WithErrorMessage("Invalid phone number format. Use international format");
+        }
+
+        [Fact]
+        public void Should_Not_Have_Error_When_Phone_Format_Is_Valid()
+        {
+            // Arrange
+            var model = new RegisterRequest { IdentityType = IdentityType.Phone, Identifier = "+12345678901", Password = "ValidPassword123" };
+
+            // Act
+            var result = _validator.TestValidate(model);
+
+            // Assert
+            result.ShouldNotHaveValidationErrorFor(x => x.Identifier);
+        }
+
+        [Fact]
+        public void Should_Have_Error_When_Phone_Password_Is_Empty()
+        {
+            // Arrange
+            var model = new RegisterRequest { IdentityType = IdentityType.Phone, Identifier = "+12345678901", Password = string.Empty };
+
+            // Act
+            var result = _validator.TestValidate(model);
+
+            // Assert
+            result.ShouldHaveValidationErrorFor(x => x.Password)
+                .WithErrorMessage("Password is required for phone registration");
+        }
+
+        // Новые тесты для Telegram
+        [Fact]
+        public void Should_Have_Error_When_Telegram_Id_Is_Invalid()
+        {
+            // Arrange
+            var model = new RegisterRequest { IdentityType = IdentityType.Telegram, Identifier = "inv", Password = "ValidPassword123" };
+
+            // Act
+            var result = _validator.TestValidate(model);
+
+            // Assert
+            result.ShouldHaveValidationErrorFor(x => x.Identifier)
+                .WithErrorMessage("Invalid Telegram ID format");
+        }
+
+        [Fact]
+        public void Should_Not_Have_Error_When_Telegram_Id_Is_Valid_Username()
+        {
+            // Arrange
+            var model = new RegisterRequest { IdentityType = IdentityType.Telegram, Identifier = "username_123" };
+
+            // Act
+            var result = _validator.TestValidate(model);
+
+            // Assert
+            result.ShouldNotHaveValidationErrorFor(x => x.Identifier);
+        }
+
+        [Fact]
+        public void Should_Not_Have_Error_When_Telegram_Id_Is_Valid_Number()
+        {
+            // Arrange
+            var model = new RegisterRequest { IdentityType = IdentityType.Telegram, Identifier = "12345678" };
+
+            // Act
+            var result = _validator.TestValidate(model);
+
+            // Assert
+            result.ShouldNotHaveValidationErrorFor(x => x.Identifier);
+        }
+
+        [Fact]
+        public void Should_Not_Require_Password_For_Telegram()
+        {
+            // Arrange
+            var model = new RegisterRequest { IdentityType = IdentityType.Telegram, Identifier = "username_123", Password = string.Empty };
+
+            // Act
+            var result = _validator.TestValidate(model);
+
+            // Assert
+            result.ShouldNotHaveValidationErrorFor(x => x.Password);
+        }
+
+        [Fact]
+        public void Should_Validate_Password_When_Provided_For_Telegram()
+        {
+            // Arrange
+            var model = new RegisterRequest { IdentityType = IdentityType.Telegram, Identifier = "username_123", Password = "short" };
+
+            // Act
+            var result = _validator.TestValidate(model);
+
+            // Assert
+            result.ShouldHaveValidationErrorFor(x => x.Password)
+                .WithErrorMessage("If provided, password must be at least 10 characters long");
+        }
+
+        // Новые тесты для WhatsApp
+        [Fact]
+        public void Should_Have_Error_When_WhatsApp_Number_Is_Invalid()
+        {
+            // Arrange
+            var model = new RegisterRequest { IdentityType = IdentityType.WhatsApp, Identifier = "invalid-whatsapp" };
+
+            // Act
+            var result = _validator.TestValidate(model);
+
+            // Assert
+            result.ShouldHaveValidationErrorFor(x => x.Identifier)
+                .WithErrorMessage("Invalid WhatsApp number format. Use international format");
+        }
+
+        [Fact]
+        public void Should_Not_Have_Error_When_WhatsApp_Number_Is_Valid()
+        {
+            // Arrange
+            var model = new RegisterRequest { IdentityType = IdentityType.WhatsApp, Identifier = "+12345678901" };
+
+            // Act
+            var result = _validator.TestValidate(model);
+
+            // Assert
+            result.ShouldNotHaveValidationErrorFor(x => x.Identifier);
+        }
+
+        [Fact]
+        public void Should_Not_Require_Password_For_WhatsApp()
+        {
+            // Arrange
+            var model = new RegisterRequest { IdentityType = IdentityType.WhatsApp, Identifier = "+12345678901", Password = string.Empty };
+
+            // Act
+            var result = _validator.TestValidate(model);
+
+            // Assert
+            result.ShouldNotHaveValidationErrorFor(x => x.Password);
+        }
+
+        [Fact]
+        public void Should_Validate_Password_When_Provided_For_WhatsApp()
+        {
+            // Arrange
+            var model = new RegisterRequest { IdentityType = IdentityType.WhatsApp, Identifier = "+12345678901", Password = "short" };
+
+            // Act
+            var result = _validator.TestValidate(model);
+
+            // Assert
+            result.ShouldHaveValidationErrorFor(x => x.Password)
+                .WithErrorMessage("If provided, password must be at least 10 characters long");
         }
     }
 }


### PR DESCRIPTION
## What

Added support for user registration and login via phone number, Telegram, and WhatsApp in the AuthCore project

## Why

To provide users with flexible authentication options beyond traditional email/password, including messaging platforms

## How to test

Test registration and login flows using a phone number, Telegram ID, and WhatsApp identifier in a development environment